### PR TITLE
fix: address comments and created overlay

### DIFF
--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -463,7 +463,7 @@ ImageViewer::createActions()
 
     toggleAreaSampleAct = new QAction(tr("&Toggle Area Sample"), this);
     toggleAreaSampleAct->setCheckable(true);
-    toggleAreaSampleAct->setShortcut(tr("E"));
+    toggleAreaSampleAct->setShortcut(tr("Ctrl+A"));
     connect(toggleAreaSampleAct, SIGNAL(triggered()), this, SLOT(toggleAreaSample()));
 }
 
@@ -2380,6 +2380,11 @@ void
 ImageViewer::toggleAreaSample()
 {
     m_areaSampleMode = !m_areaSampleMode;
+    if (m_areaSampleMode){
+        setCursor(Qt::CrossCursor);
+    } else {
+        unsetCursor();
+    }
     // if (m_areaSampleMode == false){
     //     updateStatusBar();
     // }

--- a/src/iv/imageviewer.cpp
+++ b/src/iv/imageviewer.cpp
@@ -461,7 +461,7 @@ ImageViewer::createActions()
     connect(slideShowDuration, SIGNAL(valueChanged(int)), this,
             SLOT(setSlideShowDuration(int)));
 
-    toggleAreaSampleAct = new QAction(tr("Toggle Area Sample"), this);
+    toggleAreaSampleAct = new QAction(tr("&Toggle Area Sample"), this);
     toggleAreaSampleAct->setCheckable(true);
     toggleAreaSampleAct->setShortcut(tr("E"));
     connect(toggleAreaSampleAct, SIGNAL(triggered()), this, SLOT(toggleAreaSample()));
@@ -2380,9 +2380,9 @@ void
 ImageViewer::toggleAreaSample()
 {
     m_areaSampleMode = !m_areaSampleMode;
-    if (m_areaSampleMode == false){
-        updateStatusBar();
-    }
+    // if (m_areaSampleMode == false){
+    //     updateStatusBar();
+    // }
     ((QOpenGLWidget*)(glwin))->update();
 }
 

--- a/src/iv/imageviewer.h
+++ b/src/iv/imageviewer.h
@@ -223,6 +223,11 @@ public:
         return showPixelviewWindowAct && showPixelviewWindowAct->isChecked();
     }
 
+    bool probeviewOn(void) const
+    {
+        return toggleAreaSampleAct && toggleAreaSampleAct->isChecked();
+    }
+
     bool windowguidesOn(void) const
     {
         return toggleWindowGuidesAct && toggleWindowGuidesAct->isChecked();

--- a/src/iv/ivgl.cpp
+++ b/src/iv/ivgl.cpp
@@ -710,6 +710,8 @@ IvGL::paintGL()
 
     if (m_viewer.probeviewOn()){
         paint_probeview();
+    } else {
+        m_area_probe_text.clear();
     }
 
     // Show the status info again.
@@ -995,7 +997,7 @@ IvGL::paint_probeview()
     glTranslatef(0, 0, -1); // Push into screen to draw on top
     
     float closeup_width = closeupsize * 1.3f;  
-    float closeup_height = closeupsize * 0.3f;  
+    float closeup_height = closeupsize * (0.06f * (spec.nchannels + 1));  
 
     // Position the close-up box
     const float status_bar_offset = 35.0f;
@@ -1039,6 +1041,14 @@ IvGL::paint_probeview()
     int textx = 9;
     int texty = height() - closeup_height - 30;
     int yspacing = 15;
+
+    if (m_area_probe_text.empty()) {
+    std::ostringstream oss; // Output stream
+    oss << "Area Probe:\n";
+    for (int i = 0; i < spec.nchannels; ++i)
+        oss << spec.channel_name(i) << ":   [min:  -----, max:  -----, avg:  -----]\n";
+    m_area_probe_text = oss.str();
+}
 
     std::istringstream iss(m_area_probe_text);
     std::string line;
@@ -1380,7 +1390,7 @@ IvGL::update_area_probe_text()
     QString result = "Area Probe:\n";
     for (int c = 0; c < spec.nchannels; ++c) {
         float avg = (count > 0) ? static_cast<float>(sums[c] / count) : 0.0f;
-        result += QString("%1 [min: %2  max: %3  avg: %4]\n")
+        result += QString("%1: [min: %2  max: %3  avg: %4]\n")
                     .arg(QString::fromStdString(spec.channel_name(c)).leftJustified(5))
                     .arg(min_vals[c], 6, 'f', 3)
                     .arg(max_vals[c], 6, 'f', 3)

--- a/src/iv/ivgl.h
+++ b/src/iv/ivgl.h
@@ -81,7 +81,7 @@ public:
     void get_given_image_pixel(int& x, int& y, int mouseX, int mouseY);
 
     /// What are the min/max/avg values of each channel in the selected area?
-    void analyze_selected_area();
+    void update_area_probe_text();
 
     /// Returns true if OpenGL is capable of loading textures in the sRGB color
     /// space.
@@ -130,11 +130,13 @@ protected:
     IvImage* m_current_image;      ///< Image to show on screen.
     GLuint m_pixelview_tex;        ///< Pixelview's own texture.
     bool m_pixelview_left_corner;  ///< Draw pixelview in upper left or right
+    bool m_probeview_left_corner;  ///< Draw probeview in bottom left or right
     /// Buffer passed to IvImage::copy_image when not using PBO.
     ///
     std::vector<unsigned char> m_tex_buffer;
 
     std::string m_color_shader_text;
+    std::string m_area_probe_text;
 
     /// Represents a texture object being used as a buffer.
     ///
@@ -161,6 +163,7 @@ protected:
     void focusOutEvent(QFocusEvent* event) override;
 
     void paint_pixelview();
+    void paint_probeview();
     void paint_windowguides();
     void glSquare(float xmin, float ymin, float xmax, float ymax, float z = 0);
 


### PR DESCRIPTION

## Description

This PR improves the area sampling mode in several ways:
**Overlay Display**: Area sample statistics are now shown in a semi-transparent overlay in the bottom-left corner of the viewer, rather than expanding the status bar.

**Cursor Feedback**: The cursor changes when area sample mode is active, providing immediate visual feedback that the user is in sweep mode.

**Rendering Fixes**: Resolved graphical issues that previously caused the image to jump position or briefly change color when entering or exiting area sample mode.

These changes aim to improve usability and visual clarity when inspecting per-channel pixel statistics over a selected region. Lastly, the shortcut has been changed to **Ctrl + A** to represent "Area"

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [ x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/CONTRIBUTING.md).
- [x ] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] If I added or modified a C++ API call, I have also amended the
  corresponding Python bindings (and if altering ImageBufAlgo functions, also
  exposed the new functionality as oiiotool options).
- [ ] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
